### PR TITLE
feat: Enhance time to target calculation

### DIFF
--- a/frontend/src/components/TimeToTargetChart.tsx
+++ b/frontend/src/components/TimeToTargetChart.tsx
@@ -51,6 +51,10 @@ const TimeToTargetChart: React.FC = () => {
   const [targetAmount, setTargetAmount] = useState<string>("");
   const [isLakhsInput, setIsLakhsInput] = useState<boolean>(false); // Add single state
   const [increment, setIncrement] = useState<string>("");
+  const [currentInvestments, setCurrentInvestments] = useState<string>("");
+  const [lumpsumExpenses, setLumpsumExpenses] = useState<string>("");
+  const [monthlySipAmount, setMonthlySipAmount] = useState<string>("");
+  const [sipCagr, setSipCagr] = useState<string>("");
 
   const [chartData, setChartData] = useState<any>(null); // State to hold chart data
   const [error, setError] = useState<string | null>(null);
@@ -65,7 +69,8 @@ const TimeToTargetChart: React.FC = () => {
         !maxCtc ||
         !monthlyExpense ||
         !targetAmount ||
-        !increment
+        !increment ||
+        !currentInvestments // Added currentInvestments as mandatory
       ) {
         setChartData(null); // Clear chart if inputs are incomplete
         return;
@@ -80,6 +85,11 @@ const TimeToTargetChart: React.FC = () => {
         const expenseValueRaw = parseFloat(monthlyExpense);
         const targetValueRaw = parseFloat(targetAmount);
         const incrementValueRaw = parseFloat(increment);
+        const currentInvestmentsRaw = parseFloat(currentInvestments);
+        const lumpsumExpensesRaw = lumpsumExpenses ? parseFloat(lumpsumExpenses) : 0;
+        const monthlySipAmountRaw = monthlySipAmount ? parseFloat(monthlySipAmount) : 0;
+        const sipCagrRaw = sipCagr ? parseFloat(sipCagr) : 0;
+
 
         // Apply Lakhs conversion before validation, based on single state
         const minCtcValue = isLakhsInput
@@ -97,6 +107,16 @@ const TimeToTargetChart: React.FC = () => {
         const incrementValue = isLakhsInput
           ? incrementValueRaw * 100000
           : incrementValueRaw;
+        const currentInvestmentsValue = isLakhsInput
+          ? currentInvestmentsRaw * 100000
+          : currentInvestmentsRaw;
+        const lumpsumExpensesValue = isLakhsInput
+          ? lumpsumExpensesRaw * 100000
+          : lumpsumExpensesRaw;
+        const monthlySipAmountValue = isLakhsInput
+          ? monthlySipAmountRaw * 100000
+          : monthlySipAmountRaw;
+        // No lakhs conversion for sipCagrRaw
 
         // Frontend validation (similar to backend)
         if (isNaN(minCtcValue) || minCtcValue < 0)
@@ -114,6 +134,15 @@ const TimeToTargetChart: React.FC = () => {
         if (isNaN(incrementValue) || incrementValue <= 0)
           throw new Error("Invalid Increment (must be positive)");
         if (minCtcValue > maxCtcValue) throw new Error("Min CTC > Max CTC");
+        if (isNaN(currentInvestmentsValue) || currentInvestmentsValue < 0)
+          throw new Error(`Invalid Current Investments${isLakhsInput ? " (Lakhs)" : ""}`);
+        if (isNaN(lumpsumExpensesValue) || lumpsumExpensesValue < 0)
+            throw new Error(`Invalid Lumpsum Expenses${isLakhsInput ? " (Lakhs)" : ""}`);
+        if (isNaN(monthlySipAmountValue) || monthlySipAmountValue < 0)
+            throw new Error(`Invalid Monthly SIP Amount${isLakhsInput ? " (Lakhs)" : ""}`);
+        if (isNaN(sipCagrRaw) || sipCagrRaw < 0 || sipCagrRaw > 200) // Assuming 200% is a generous upper limit
+            throw new Error("Invalid SIP CAGR (%). Please enter a value between 0 and 200.");
+
 
         // Construct API URL using environment variable
         const apiUrl = `${
@@ -133,6 +162,10 @@ const TimeToTargetChart: React.FC = () => {
               monthlyExpense: expenseValue,
               targetAmount: targetValue,
               increment: incrementValue,
+              currentInvestments: currentInvestmentsValue,
+              lumpsumExpenses: lumpsumExpensesValue,
+              monthlySipAmount: monthlySipAmountValue,
+              sipCagr: sipCagrRaw / 100, // Convert percentage to decimal
             }),
           }
         );
@@ -336,6 +369,7 @@ const TimeToTargetChart: React.FC = () => {
           marginBottom: "15px",
         }}
       >
+        {/* Row 1 */}
         <div>
           <label htmlFor="minCtcTarget">Min CTC (INR):</label>
           <div
@@ -376,6 +410,7 @@ const TimeToTargetChart: React.FC = () => {
             />
           </div>
         </div>
+        {/* Row 2 */}
         <div>
           <label htmlFor="monthlyExpenseTarget">Monthly Expense (INR):</label>
           <div
@@ -416,6 +451,53 @@ const TimeToTargetChart: React.FC = () => {
             />
           </div>
         </div>
+        {/* Row 3 */}
+        <div>
+          <label htmlFor="currentInvestments">Current Investments (INR):</label>
+          <input
+            type="number"
+            id="currentInvestments"
+            value={currentInvestments}
+            onChange={(e) => setCurrentInvestments(e.target.value)}
+            placeholder={isLakhsInput ? "e.g., 20" : "e.g., 2000000"}
+            style={{ width: "100%", padding: "8px", boxSizing: "border-box", marginTop: "5px" }}
+          />
+        </div>
+        <div>
+          <label htmlFor="lumpsumExpenses">Lumpsum Expenses (INR) (Optional):</label>
+          <input
+            type="number"
+            id="lumpsumExpenses"
+            value={lumpsumExpenses}
+            onChange={(e) => setLumpsumExpenses(e.target.value)}
+            placeholder={isLakhsInput ? "e.g., 1" : "e.g., 100000"}
+            style={{ width: "100%", padding: "8px", boxSizing: "border-box", marginTop: "5px" }}
+          />
+        </div>
+        {/* Row 4 */}
+        <div>
+          <label htmlFor="monthlySipAmount">Monthly SIP (INR) (Optional):</label>
+          <input
+            type="number"
+            id="monthlySipAmount"
+            value={monthlySipAmount}
+            onChange={(e) => setMonthlySipAmount(e.target.value)}
+            placeholder={isLakhsInput ? "e.g., 0.1" : "e.g., 10000"}
+            style={{ width: "100%", padding: "8px", boxSizing: "border-box", marginTop: "5px" }}
+          />
+        </div>
+        <div>
+          <label htmlFor="sipCagr">Expected SIP CAGR (%) (Optional):</label>
+          <input
+            type="number"
+            id="sipCagr"
+            value={sipCagr}
+            onChange={(e) => setSipCagr(e.target.value)}
+            placeholder="e.g., 12 (for 12%)"
+            style={{ width: "100%", padding: "8px", boxSizing: "border-box", marginTop: "5px" }}
+          />
+        </div>
+        {/* Row 5 - Increment can be here or in Row 3 if preferred */}
         <div>
           <label htmlFor="incrementTarget">Increment (INR):</label>
           <input
@@ -443,7 +525,8 @@ const TimeToTargetChart: React.FC = () => {
           !maxCtc ||
           !monthlyExpense ||
           !targetAmount ||
-          !increment
+          !increment ||
+          !currentInvestments // Added currentInvestments as mandatory
         }
         style={{
           padding: "10px 15px",
@@ -477,7 +560,8 @@ const TimeToTargetChart: React.FC = () => {
         maxCtc &&
         monthlyExpense &&
         targetAmount &&
-        increment && (
+        increment &&
+        currentInvestments && ( // Added currentInvestments
           <div style={{ marginTop: "15px", color: "var(--color-text-secondary)" }}>
             Enter values and click Generate Chart.
           </div>

--- a/src/main/java/com/example/taxcalculator/dto/TimeToTargetRequest.java
+++ b/src/main/java/com/example/taxcalculator/dto/TimeToTargetRequest.java
@@ -9,4 +9,8 @@ public class TimeToTargetRequest {
     private double monthlyExpense;
     private double targetAmount;
     private Double increment;
+    private Double currentInvestments;
+    private Double lumpsumExpenses;
+    private Double monthlySipAmount;
+    private Double sipCagr;
 } 

--- a/src/test/java/com/example/taxcalculator/service/TaxCalculationServiceTests.java
+++ b/src/test/java/com/example/taxcalculator/service/TaxCalculationServiceTests.java
@@ -1,0 +1,141 @@
+package com.example.taxcalculator.service;
+
+import com.example.taxcalculator.dto.TimeToTargetRequest;
+import com.example.taxcalculator.dto.TimeToTargetResponse;
+import com.example.taxcalculator.dto.TimeToTargetResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaxCalculationServiceTests {
+
+    private TaxCalculationService taxCalculationService;
+
+    @BeforeEach
+    void setUp() {
+        taxCalculationService = new TaxCalculationService();
+    }
+
+    private TimeToTargetRequest createBasicRequest(double ctc, double monthlyExpense, double targetAmount) {
+        TimeToTargetRequest request = new TimeToTargetRequest();
+        request.setMinCtc(ctc);
+        request.setMaxCtc(ctc); // Test single CTC value
+        request.setMonthlyExpense(monthlyExpense);
+        request.setTargetAmount(targetAmount);
+        request.setIncrement(100000.0); // Increment doesn't matter if minCtc = maxCtc
+        // Defaults for new fields, can be overridden in specific tests
+        request.setCurrentInvestments(0.0);
+        request.setLumpsumExpenses(0.0);
+        request.setMonthlySipAmount(0.0);
+        request.setSipCagr(0.0);
+        return request;
+    }
+
+    @Test
+    void testTargetAlreadyMet() {
+        TimeToTargetRequest request = createBasicRequest(1000000, 20000, 500000);
+        request.setCurrentInvestments(600000.0); // Already above target
+
+        TimeToTargetResponse response = taxCalculationService.calculateTimeToTargetForRange(request);
+        assertNotNull(response);
+        assertNotNull(response.getResults());
+        assertFalse(response.getResults().isEmpty());
+        TimeToTargetResult result = response.getResults().get(0);
+        assertEquals(0.0, result.getTimeToTargetMonths(), "Target should be met in 0 months if current investments exceed target.");
+    }
+
+    @Test
+    void testBasicTimeToTarget_NoInvestmentsOrSip() {
+        TimeToTargetRequest request = createBasicRequest(1200000, 30000, 1000000);
+
+        TimeToTargetResponse response = taxCalculationService.calculateTimeToTargetForRange(request);
+        assertNotNull(response);
+        assertNotNull(response.getResults());
+        assertFalse(response.getResults().isEmpty());
+        TimeToTargetResult result = response.getResults().get(0);
+        assertEquals(15.0, result.getTimeToTargetMonths(), "Basic time to target calculation without investments/SIP.");
+    }
+
+    @Test
+    void testTimeToTarget_WithCurrentInvestments() {
+        TimeToTargetRequest request = createBasicRequest(1200000, 30000, 1000000);
+        request.setCurrentInvestments(200000.0);
+
+        TimeToTargetResponse response = taxCalculationService.calculateTimeToTargetForRange(request);
+        TimeToTargetResult result = response.getResults().get(0);
+        assertEquals(12.0, result.getTimeToTargetMonths(), "Time to target with current investments.");
+    }
+
+    @Test
+    void testTimeToTarget_WithLumpsumExpense() {
+        TimeToTargetRequest request = createBasicRequest(1200000, 30000, 1000000);
+        request.setCurrentInvestments(200000.0);
+        request.setLumpsumExpenses(50000.0);
+
+        TimeToTargetResponse response = taxCalculationService.calculateTimeToTargetForRange(request);
+        TimeToTargetResult result = response.getResults().get(0);
+        assertEquals(13.0, result.getTimeToTargetMonths(), "Time to target with lumpsum expenses.");
+    }
+
+    @Test
+    void testTimeToTarget_WithSipNoCagr() {
+        TimeToTargetRequest request = createBasicRequest(1200000, 30000, 1000000);
+        request.setMonthlySipAmount(10000.0);
+
+        TimeToTargetResponse response = taxCalculationService.calculateTimeToTargetForRange(request);
+        TimeToTargetResult result = response.getResults().get(0);
+        assertEquals(13.0, result.getTimeToTargetMonths(), "Time to target with SIP but no CAGR.");
+    }
+    
+    @Test
+    void testTimeToTarget_WithSipAndCagr() {
+        TimeToTargetRequest request = createBasicRequest(1200000, 50000, 500000);
+        request.setCurrentInvestments(50000.0);
+        request.setMonthlySipAmount(10000.0);
+        request.setSipCagr(0.12);
+
+        TimeToTargetResponse response = taxCalculationService.calculateTimeToTargetForRange(request);
+        TimeToTargetResult result = response.getResults().get(0);
+        assertEquals(8.0, result.getTimeToTargetMonths(), "Time to target with SIP and CAGR.");
+    }
+
+    @Test
+    void testUnachievable_ExpensesExceedIncome() {
+        TimeToTargetRequest request = createBasicRequest(1000000, 90000, 1000000);
+
+        TimeToTargetResponse response = taxCalculationService.calculateTimeToTargetForRange(request);
+        TimeToTargetResult result = response.getResults().get(0);
+        assertEquals(Double.POSITIVE_INFINITY, result.getTimeToTargetMonths(), "Unachievable: Expenses exceed income.");
+    }
+
+    @Test
+    void testUnachievable_SipPlusExpensesExceedIncome() {
+        TimeToTargetRequest request = createBasicRequest(1000000, 70000, 1000000);
+        request.setMonthlySipAmount(15000.0);
+
+        TimeToTargetResponse response = taxCalculationService.calculateTimeToTargetForRange(request);
+        TimeToTargetResult result = response.getResults().get(0);
+        assertEquals(Double.POSITIVE_INFINITY, result.getTimeToTargetMonths(), "Unachievable: SIP + Expenses exceed income.");
+    }
+    
+    @Test
+    void testUnachievable_NetSavingsEffectivelyZero_NoGrowth() {
+        TimeToTargetRequest request = createBasicRequest(1000000, 83333.0, 1000000);
+        request.setCurrentInvestments(100000.0);
+
+        TimeToTargetResponse response = taxCalculationService.calculateTimeToTargetForRange(request);
+        TimeToTargetResult result = response.getResults().get(0);
+        assertEquals(Double.POSITIVE_INFINITY, result.getTimeToTargetMonths(), "Unachievable: Net savings very close to zero, no growth, should hit max duration or stagnation.");
+    }
+
+     @Test
+    void testUnachievable_NetSavingsZero_NoGrowth_StrictZeroSavings() {
+        TimeToTargetRequest request = createBasicRequest(1200000, 100000, 1000000);
+        request.setCurrentInvestments(100000.0);
+
+        TimeToTargetResponse response = taxCalculationService.calculateTimeToTargetForRange(request);
+        TimeToTargetResult result = response.getResults().get(0);
+        assertEquals(Double.POSITIVE_INFINITY, result.getTimeToTargetMonths(), "Unachievable: Net savings strictly zero, no growth.");
+    }
+}


### PR DESCRIPTION
Incorporates net worth and investment growth in 'time to target' feature.

Key changes:
- Target is now a net worth target (investments + savings).
- You can declare current investments.
- You can declare one-time (lumpsum) expenses, which are deducted from current net worth.
- You can declare a monthly SIP amount and its expected CAGR.
- The backend calculation iteratively projects monthly net worth growth considering salary savings, SIP contributions, and investment growth (CAGR).
- Added logical check: If monthly expenses + SIP > monthly take-home, target is marked unachievable for that CTC.
- Frontend (TimeToTargetChart.tsx) updated with new input fields for these parameters and sends them in the API request.
- Y-axis for the chart remains in months.
- Added comprehensive backend unit tests for TaxCalculationService to cover new scenarios including various financial inputs and edge cases like unachievable targets.