### PR TITLE
fix: Correct compilation error in time to target calculation

### DIFF
--- a/src/main/java/com/example/taxcalculator/service/TaxCalculationService.java
+++ b/src/main/java/com/example/taxcalculator/service/TaxCalculationService.java
@@ -209,7 +209,6 @@ public class TaxCalculationService {
                     .build());
 
             if (currentCtc >= maxCtc) {
-            if (currentCtc >= maxCtc) {
                 break; // Exit loop
             }
 


### PR DESCRIPTION
Resolves an "illegal start of expression" error in TaxCalculationService.java caused by a duplicated conditional block within the calculateTimeToTargetForRange method.

The duplicated block was removed, ensuring the loop structure for CTC iteration is correct and the service compiles successfully.

This commit ensures the stability of the recently enhanced time-to-target feature.